### PR TITLE
Fix Python 3.13 compatibility in asaph_generate_data

### DIFF
--- a/bin/asaph_generate_data
+++ b/bin/asaph_generate_data
@@ -69,7 +69,7 @@ def pops_writer(flname, n_individuals, n_populations):
         pops[name ] = []
 
     for i in range(n_individuals):
-        pop = random.sample(pops.keys(), 1)[0]
+        pop = random.sample(list(pops.keys()), 1)[0]
         pops[pop].append(str(i))
 
     with open(flname, "w", encoding="utf-8") as fl:


### PR DESCRIPTION
Fix TypeError in random.sample() call by converting dict_keys to list. In Python 3.13, random.sample() requires a sequence, not dict_keys.

🤖 Generated with [Claude Code](https://claude.ai/code)